### PR TITLE
Bugfixes and upgraded to v0.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ifttt-lint",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A high-concurrency IFTTT (IfThisThenThat) linter",
   "homepage": "https://www.github.com/ebrevdo/ifttt-lint",
   "main": "dist/main.js",

--- a/tests/DiffParser.test.ts
+++ b/tests/DiffParser.test.ts
@@ -1,0 +1,61 @@
+import { parseChangedLines } from '../src/DiffParser';
+
+describe('parseChangedLines spurious header filtering', () => {
+  it('ignores comment lines starting with --- without valid path', () => {
+    const diff = [
+      'diff --git a/file.sql b/file.sql',
+      'index abc..def 100644',
+      '--- a/file.sql',
+      '+++ b/file.sql',
+      '@@ -1,6 +1,6 @@',
+      ' SELECT *',
+      '+SELECT hello',
+      ' --- This is a comment, not a file header',
+      '-OLD LINE',
+      '+NEW LINE'
+    ].join('\n');
+    const result = parseChangedLines(diff);
+    // Only one file should be parsed
+    expect(result.size).toBe(1);
+    expect(result.has('file.sql')).toBe(true);
+    const changes = result.get('file.sql')!;
+    // Added lines at newLine positions 2 and 4
+    expect(changes.addedLines.has(2)).toBe(true);
+    expect(changes.addedLines.has(4)).toBe(true);
+    // Removed line at oldLine position 3
+    expect(changes.removedLines.has(3)).toBe(true);
+  });
+
+  it('retains real file header lines starting with --- a/ or +++ b/', () => {
+    const diff = [
+      'diff --git a/foo.js b/foo.js',
+      'index 123..456 100644',
+      '--- a/foo.js',
+      '+++ b/foo.js',
+      '@@ -0,0 +1,1 @@',
+      '+console.log("hi");'
+    ].join('\n');
+    const result = parseChangedLines(diff);
+    expect(result.size).toBe(1);
+    expect(Array.from(result.keys())).toEqual(['foo.js']);
+    const changes = result.get('foo.js')!;
+    expect(changes.addedLines.has(1)).toBe(true);
+  });
+  it('accepts file headers with arbitrary prefixes (e.g., c/ and w/)', () => {
+    const diff = [
+      'diff --git c/path/file.txt w/path/file.txt',
+      'index 123..456 100644',
+      '--- c/path/file.txt',
+      '+++ w/path/file.txt',
+      '@@ -1 +1 @@',
+      '-old line',
+      '+new line'
+    ].join('\n');
+    const result = parseChangedLines(diff);
+    expect(result.size).toBe(1);
+    expect(result.has('path/file.txt')).toBe(true);
+    const changes = result.get('path/file.txt')!;
+    expect(changes.removedLines.has(1)).toBe(true);
+    expect(changes.addedLines.has(1)).toBe(true);
+  });
+});

--- a/tests/DirectiveParserList.test.ts
+++ b/tests/DirectiveParserList.test.ts
@@ -48,4 +48,11 @@ describe('DirectiveParser ThenChange array literal', () => {
       { kind: 'ThenChange', line: 1, target: 'file2.ts#lbl' }
     ]);
   });
+  describe('parseFileDirectives on directories', () => {
+    it('returns empty directive list for directory paths', async () => {
+      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lint-dir-'));
+      const directives = await parseFileDirectives(tmpDir);
+      expect(directives).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
* Bugfix: Support octal-escaped filenames coming from git diff.
* Bugfix: don't try to open directories, better handling of `--- ...` non-filename diffs.
* Bugfix: Warn instead of failing if the comment extractor sees an unknown file.