### PR TITLE
Fix Diff Parsing for Deleted Files

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -49,9 +49,14 @@ export async function runLint(
   // Validate diff input: non-empty text must yield at least one file change
   const changesMap = parseChangedLines(diffText);
   if (diffText.trim().length > 0 && changesMap.size === 0) {
-    // Input text provided but no diff files detected
-    const snippet = diffText.slice(0, 100).replace(/\r?\n/g, '\\n');
-    throw new Error(`Invalid diff input: no file changes detected (snippet: "${snippet}...")`);
+    // Check if the diff contains any valid file operations (including deletions)
+    // Look for diff headers that indicate file operations
+    const hasValidFileOps = /^(---|diff --git|index [0-9a-f]+\.\.[0-9a-f]+)/m.test(diffText);
+    if (!hasValidFileOps) {
+      // Input text provided but no diff files detected
+      const snippet = diffText.slice(0, 100).replace(/\r?\n/g, '\\n');
+      throw new Error(`Invalid diff input: no file changes detected (snippet: "${snippet}...")`);
+    }
   }
   // Log parallelism to stderr for verbose output only
   if (verbose) {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -41,6 +41,21 @@ describe('runLint', () => {
     await expect(runLint({ diffText: 'not a diff' }, concurrency, true))
       .rejects.toThrow('Invalid diff input');
   });
+
+  it('handles diff with only deleted files without error', async () => {
+    // Valid diff format with only deleted files (to /dev/null) should not throw error
+    const deletedFileDiff = `diff --git a/infrastructure/terraform/env-corp/us-west-2/aws-corp/s3-sync.tf b/infrastructure/terraform/env-corp/us-west-2/aws-corp/s3-sync.tf
+deleted file mode 100644
+index 1234567..0000000
+--- a/infrastructure/terraform/env-corp/us-west-2/aws-corp/s3-sync.tf
++++ /dev/null
+@@ -1,10 +0,0 @@
+-resource "aws_s3_bucket" "sync" {
+-  bucket = "my-sync-bucket"
+-}`;
+    const code = await runLint({ diffText: deletedFileDiff }, concurrency, true);
+    expect(code).toBe(0);
+  });
 });
 
 describe('parseCliArgs', () => {


### PR DESCRIPTION
Fix issue where runLint throws errors on valid diffs containing only deleted files. Update diff validation to check for file operation headers, so code handles deletions (e.g., to /dev/null) correctly. Add a test case for deleted file diffs.