### PR TITLE
Add Markdown and Makefile support to directive parser

### DIFF
--- a/src/DirectiveParser.ts
+++ b/src/DirectiveParser.ts
@@ -19,6 +19,46 @@ const thenChangeRegex = /LINT\.ThenChange\(['"]([^'"]+)['"]\)/;
 const labelRegex = /LINT\.Label\(['"]([^'"]+)['"]\)/;
 const endLabelRegex = /LINT\.EndLabel/;
 
+type CommentsMap = Record<string, { content?: string }>;
+
+// The comment extractor selects syntax by filename/extension. Rather than rely on
+// every extension being recognized, we normalize unrecognized files to a small set
+// of representative filenames whose comment syntax is known to be supported:
+//   x.py   -> hash comments (#)
+//   x.js   -> slash comments (//, /* */)
+//   x.html -> HTML comments (<!-- -->)
+const REP_HASH = 'x.py';
+const REP_SLASH = 'x.js';
+const REP_HTML = 'x.html';
+
+/**
+ * Maps a file path to a representative filename with a known comment syntax,
+ * used when the extractor cannot recognize the file directly. Returns null when
+ * we have no sensible default.
+ */
+function representativeFilename(filePath: string): string | null {
+  const base = path.basename(filePath);
+  const ext = path.extname(filePath).toLowerCase();
+  // Makefile family and other hash-comment files
+  if (/^(gnu)?makefile$/i.test(base) || ext === '.mk' || ext === '.bzl') {
+    return REP_HASH;
+  }
+  // Default to slash-comment syntax (preserves prior behavior for unknown types)
+  return REP_SLASH;
+}
+
+/**
+ * Runs the comment extractor for the given representative filename, returning
+ * null instead of throwing when the content has no extractable comments.
+ */
+function tryExtract(content: string, filename: string): CommentsMap | null {
+  try {
+    return extractComments(content, { filename }) as CommentsMap;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Parses lint directives from comments in the specified file.
  * Uses the extract-comments library to find comment blocks and line comments,
@@ -43,29 +83,36 @@ export async function parseFileDirectives(
     // Propagate other errors (e.g., permission issues)
     throw err;
   }
-  // Use multi-language comment extractor to find all comments in source
-  // Pass filename so extractor can choose comment syntax by extension
-  let commentsMap: Record<string, { content?: string }>;
-  // Try extracting comments by file extension; if unsupported, fall back or warn
-  try {
-    commentsMap = extractComments(content, { filename: filePath });
-  } catch {
-    const ext = path.extname(filePath).toLowerCase();
-    let fallback: string;
-    if (ext === '.bzl') {
-      // Treat Bazel/Starlark files as Python for comment syntax (#)
-      fallback = filePath.replace(/\.bzl$/i, '.py');
-    } else {
-      // Default to JavaScript
-      fallback = filePath.replace(path.extname(filePath), '.js');
-    }
-    try {
-      commentsMap = extractComments(content, { filename: fallback });
-    } catch {
-      // Could not extract comments (e.g., JSON or unsupported extensions): ignore silently
-      return [];
-    }
+  const ext = path.extname(filePath).toLowerCase();
+  // Markdown uses HTML comment syntax (<!-- LINT.IfChange -->), which the
+  // extractor doesn't recognize from the .md extension, so normalize it.
+  if (ext === '.md' || ext === '.markdown') {
+    const mdMap = tryExtract(content, REP_HTML);
+    return mdMap ? directivesFromCommentsMap(mdMap, filePath) : [];
   }
+
+  // Use multi-language comment extractor to find all comments in source.
+  // Try the path as-is first (recognizes Makefile, *.py, *.html, etc.); if the
+  // extractor can't determine the syntax, retry with a representative filename.
+  let commentsMap = tryExtract(content, filePath);
+  if (commentsMap === null) {
+    const rep = representativeFilename(filePath);
+    commentsMap = rep ? tryExtract(content, rep) : null;
+  }
+  if (commentsMap === null) {
+    // Could not extract comments (e.g., JSON or unsupported extensions): ignore silently
+    return [];
+  }
+  return directivesFromCommentsMap(commentsMap, filePath);
+}
+
+/**
+ * Walks an extracted comment map and returns the LINT directives within it.
+ */
+function directivesFromCommentsMap(
+  commentsMap: CommentsMap,
+  filePath: string
+): LintDirective[] {
   // commentsMap maps starting line numbers (as strings) to comment objects
   const directives: LintDirective[] = [];
   for (const [beginStr, comment] of Object.entries(commentsMap)) {

--- a/tests/DirectiveParserFileTypes.test.ts
+++ b/tests/DirectiveParserFileTypes.test.ts
@@ -1,0 +1,98 @@
+import { parseFileDirectives } from '../src/DirectiveParser';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+
+describe('DirectiveParser file-type support', () => {
+  let tmpDir: string;
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lint-ft-'));
+  });
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('Markdown', () => {
+    it('parses directives from HTML comments in .md files', async () => {
+      const file = path.join(tmpDir, 'doc.md');
+      const content = [
+        '# Heading',
+        '<!-- LINT.IfChange -->',
+        'Some prose describing config.',
+        '<!-- LINT.ThenChange("config.py") -->'
+      ].join('\n');
+      await fs.writeFile(file, content, 'utf-8');
+      const directives = await parseFileDirectives(file);
+      expect(directives).toEqual([
+        { kind: 'IfChange', line: 2 },
+        { kind: 'ThenChange', line: 4, target: 'config.py' }
+      ]);
+    });
+
+    it('parses labeled IfChange and array ThenChange in .markdown files', async () => {
+      const file = path.join(tmpDir, 'doc.markdown');
+      const content = [
+        '<!-- LINT.IfChange("docs") -->',
+        'text',
+        "<!-- LINT.ThenChange(['a.py', 'b.ts#foo']) -->"
+      ].join('\n');
+      await fs.writeFile(file, content, 'utf-8');
+      const directives = await parseFileDirectives(file);
+      expect(directives).toEqual([
+        { kind: 'IfChange', line: 1, label: 'docs' },
+        { kind: 'ThenChange', line: 3, target: 'a.py' },
+        { kind: 'ThenChange', line: 3, target: 'b.ts#foo' }
+      ]);
+    });
+
+    it('returns no directives for markdown without LINT comments', async () => {
+      const file = path.join(tmpDir, 'plain.md');
+      await fs.writeFile(file, '# Title\n\nJust prose, no directives.\n', 'utf-8');
+      const directives = await parseFileDirectives(file);
+      expect(directives).toEqual([]);
+    });
+  });
+
+  describe('Makefiles', () => {
+    const mkContent = [
+      '# LINT.IfChange',
+      'SOMEVAR = 1',
+      '# LINT.ThenChange("config.py")'
+    ].join('\n');
+    const expected = [
+      { kind: 'IfChange', line: 1 },
+      { kind: 'ThenChange', line: 3, target: 'config.py' }
+    ];
+
+    it.each([
+      ['Makefile'],
+      ['makefile'],
+      ['GNUmakefile'],
+      ['build.mk']
+    ])('parses # directives in %s', async (name) => {
+      const file = path.join(tmpDir, name);
+      await fs.writeFile(file, mkContent, 'utf-8');
+      const directives = await parseFileDirectives(file);
+      expect(directives).toEqual(expected);
+    });
+
+    it('parses a multi-line ThenChange array in a Makefile', async () => {
+      const file = path.join(tmpDir, 'Makefile');
+      const content = [
+        '# LINT.IfChange',
+        'SOMEVAR = 1',
+        '# LINT.ThenChange(',
+        "#  ['py_config.py',",
+        "#   'ts_config.ts#foo'],",
+        '# )'
+      ].join('\n');
+      await fs.writeFile(file, content, 'utf-8');
+      const directives = await parseFileDirectives(file);
+      expect(directives).toEqual([
+        { kind: 'IfChange', line: 1 },
+        { kind: 'ThenChange', line: 3, target: 'py_config.py' },
+        { kind: 'ThenChange', line: 3, target: 'ts_config.ts#foo' }
+      ]);
+    });
+  });
+});

--- a/tests/LintEngineLang.test.ts
+++ b/tests/LintEngineLang.test.ts
@@ -81,4 +81,63 @@ describe('cross-language lint directives', () => {
     const code = await lintDiff(diff, 1, true);
     expect(code).toBe(1);
   });
+
+  test('passes when a Markdown IfChange and its Makefile target both change', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lintlang-'));
+    const fileMD = path.join(tmpDir, 'doc.md');
+    const fileMK = path.join(tmpDir, 'Makefile');
+    const mdContent = [
+      '<!-- LINT.IfChange -->',
+      'Docs for the build var.',
+      '<!-- LINT.ThenChange("Makefile") -->'
+    ].join('\n');
+    const mkContent = ['# LINT.Label("var")', 'SOMEVAR = 1', '# LINT.EndLabel'].join('\n');
+    await fs.writeFile(fileMD, mdContent);
+    await fs.writeFile(fileMK, mkContent);
+    // Change both the markdown doc and the Makefile.
+    const diff = [
+      `--- a/${fileMD}`,
+      `+++ b/${fileMD}`,
+      '@@ -1,3 +1,3 @@',
+      '-<!-- LINT.IfChange -->',
+      '+<!-- LINT.IfChange --> <!-- changed -->',
+      ' Docs for the build var.',
+      ' <!-- LINT.ThenChange("Makefile") -->',
+      `--- a/${fileMK}`,
+      `+++ b/${fileMK}`,
+      '@@ -1,3 +1,3 @@',
+      ' # LINT.Label("var")',
+      '-SOMEVAR = 1',
+      '+SOMEVAR = 2',
+      ' # LINT.EndLabel'
+    ].join('\n');
+    const result = await lintDiff(diff, 1, true);
+    expect(result).toBe(0);
+  });
+
+  test('fails when a Makefile IfChange target Markdown file is not changed', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lintlang-'));
+    const fileMK = path.join(tmpDir, 'Makefile');
+    const fileMD = path.join(tmpDir, 'README.md');
+    const mkContent = [
+      '# LINT.IfChange',
+      'SOMEVAR = 1',
+      '# LINT.ThenChange("README.md")'
+    ].join('\n');
+    const mdContent = ['# Project', '', 'Docs.'].join('\n');
+    await fs.writeFile(fileMK, mkContent);
+    await fs.writeFile(fileMD, mdContent);
+    // Change the Makefile but not the markdown target.
+    const diff = [
+      `--- a/${fileMK}`,
+      `+++ b/${fileMK}`,
+      '@@ -1,3 +1,3 @@',
+      ' # LINT.IfChange',
+      '-SOMEVAR = 1',
+      '+SOMEVAR = 2',
+      ' # LINT.ThenChange("README.md")'
+    ].join('\n');
+    const code = await lintDiff(diff, 1, true);
+    expect(code).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary

Extends the directive parser to recognize LINT directives in **Markdown** and **Makefile** files.

- **Markdown** (`.md`/`.markdown`): parses directives from HTML comments (`<!-- LINT.IfChange -->`). Directives inside fenced code blocks are intentionally **not** supported — use prose comments instead.
- **Makefiles**: recognizes `Makefile`, `makefile`, `GNUmakefile`, and `*.mk` as hash-comment files. (`Makefile` already worked via the underlying library; the variants did not.)

## Implementation

Replaces the fragile "rewrite extension to `.js`" fallback in `DirectiveParser` with a **representative-filename** approach: when the comment extractor can't determine a file's syntax, it normalizes to a known-good filename — `x.py` (`#`), `x.js` (`//`), or `x.html` (`<!-- -->`). The existing `.bzl` → `#` mapping is preserved, and unsupported types still silently yield no directives (unchanged behavior).

## Tests

- New `tests/DirectiveParserFileTypes.test.ts` — unit coverage for Markdown (HTML comments, labels, array `ThenChange`, no-directive case) and all Makefile name variants plus the multi-line `ThenChange` array.
- Two end-to-end `lintDiff` cases appended to `tests/LintEngineLang.test.ts`.

All 7 suites / 80 tests pass (`npm test`, which runs build + lint + tsc + jest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)